### PR TITLE
Get Android Build Flavors Working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ app.*.map.json
 /android/app/release
 
 # Firebase related
-/android/app/google-services.json
+google-services.json

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,8 +34,9 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "org.hackpsu"
+        // If you run "flutter ["run"/"build"]" without --flavor prod, it will by default build the dev version.
+        // To test with prod data, run "flutter run --flavor prod"
+        applicationId "org.hackpsu.dev"
         minSdkVersion 16
         targetSdkVersion 30
         multiDexEnabled true
@@ -48,6 +49,15 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+        }
+    }
+
+    flavorDimensions "app"
+
+    productFlavors {
+        prod {
+            dimension "app"
+            applicationId "org.hackpsu.prod"
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.hackpsu">
+   <uses-permission android:name="android.permission.INTERNET" />
    <application
         android:label="hackpsu"
         android:icon="@mipmap/ic_launcher">

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -188,7 +188,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -223,7 +223,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
There are 2 `google-services.json` files now (one for dev and one for prod) not in the repo. With that, though, both prod and dev signins work perfectly