### PR TITLE
added default icons for each event type

### DIFF
--- a/lib/card_items/event_workshop_card.dart
+++ b/lib/card_items/event_workshop_card.dart
@@ -63,14 +63,6 @@ class EventWorkshopCard extends StatelessWidget {
               padding: const EdgeInsets.symmetric(vertical: 8.0),
               child: Row(
                 children: [
-                  if (event.eventIcon != null)
-                    Padding(
-                      padding: const EdgeInsets.only(left: 10.0),
-                      child: CircleAvatar(
-                        radius: 25,
-                        backgroundImage: NetworkImage(event.eventIcon),
-                      ),
-                    ),
                   const Padding(padding: EdgeInsets.only(right: 10.0)),
                   Expanded(
                     child: Column(
@@ -156,6 +148,31 @@ class _BottomSheet {
         borderRadius: BorderRadius.vertical(top: Radius.circular(10)),
       ),
       builder: (BuildContext context) {
+        Icon getEventIcon(EventType eventType) {
+          if (eventType == EventType.ACTIVITY) {
+            return const Icon(
+              Icons.event_available,
+              size: 40,
+            );
+          }
+          if (eventType == EventType.FOOD) {
+            return const Icon(
+              Icons.fastfood,
+              size: 40,
+            );
+          }
+          if (eventType == EventType.WORKSHOP) {
+            return const Icon(
+              Icons.co_present,
+              size: 40,
+            );
+          }
+          return const Icon(
+            Icons.error,
+            size: 40,
+          );
+        }
+
         return BlocBuilder<FavoritesBloc, FavoritesState>(
           buildWhen: buildWhen,
           builder: (context, state) {
@@ -168,20 +185,21 @@ class _BottomSheet {
                   Row(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      if (event.eventIcon != null)
-                        Padding(
-                          padding: const EdgeInsets.only(top: 5.0, right: 10.0),
-                          child: CircleAvatar(
-                              radius: 25,
-                              backgroundImage: NetworkImage(event.eventIcon)),
-                        ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 5.0, right: 10.0),
+                        child: event.eventIcon != null
+                            ? CircleAvatar(
+                                radius: 25,
+                                backgroundImage: NetworkImage(event.eventIcon))
+                            : getEventIcon(event.eventType),
+                      ),
                       Expanded(
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             DefaultText(
                               event.eventTitle,
-                              textLevel: TextLevel.overline,
+                              textLevel: TextLevel.sub1,
                             ),
                             if (event.wsPresenterNames != null)
                               DefaultText(


### PR DESCRIPTION
I got rid of the event icons on the card and then added the icons and default icons for the bottom sheet modal that shows when you tap on the card. There's a different icon for each event type. The card itself looks less smushed this way.

![image](https://user-images.githubusercontent.com/70663263/161403829-fd944b48-84c9-48d0-a100-17628e329cf1.png)
![image](https://user-images.githubusercontent.com/70663263/161403863-25287276-916a-4bc8-a6ea-b19874d9c384.png)
![image](https://user-images.githubusercontent.com/70663263/161403871-48e10935-178c-42a4-a59f-8a9f0544f23f.png)
